### PR TITLE
Upgrade PyYAML

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -28,7 +28,7 @@ pylint-plugin-utils==0.6
 pyparsing==2.4.6
 pytest==5.3.4
 pytest-cov==2.8.1
-PyYAML==5.3
+PyYAML==5.4.1
 rasterio==1.1.2
 requirements-detector==0.6
 setoptconf==0.2.0


### PR DESCRIPTION
Upgrade PyYAML package version due to security issues presented in 5.3 or under versions